### PR TITLE
[TEST] Unit Test for Comment Domain

### DIFF
--- a/src/main/java/animealth/animealthbackend/api/comment/dto/CreateCommentDTO.java
+++ b/src/main/java/animealth/animealthbackend/api/comment/dto/CreateCommentDTO.java
@@ -12,21 +12,32 @@ public class CreateCommentDTO {
         private Long parentCommentId;
         private String content;
         private Long articleId;
+
+        @Builder
+        public CreateCommentRequestDTO(Long parentCommentId, String content, Long articleId) {
+            this.parentCommentId = parentCommentId;
+            this.content = content;
+            this.articleId = articleId;
+        }
     }
 
     @Getter
     public static class CreateCommentResponseDTO {
         private final Long commentId;
         private final String writer;
+        private final Long articleId;
         private final String content;
         private final int depth;
         private final GetCommentResponseDTO parentComment;
         private final List<Comment> childComments;
 
         @Builder
-        public CreateCommentResponseDTO(Long commentId, String writer, String content, int depth, Comment parentComment, List<Comment> childComments) {
+        public CreateCommentResponseDTO(Long commentId, String writer, Long articleId, String content, int depth,
+                                        Comment parentComment, List<Comment> childComments
+        ) {
             this.commentId = commentId;
             this.writer = writer;
+            this.articleId = articleId;
             this.content = content;
             this.depth = depth;
             this.parentComment = GetCommentResponseDTO.from(parentComment);
@@ -37,6 +48,7 @@ public class CreateCommentDTO {
             return CreateCommentResponseDTO.builder()
                     .commentId(comment.getId())
                     .writer(comment.getWriter().getNickname())
+                    .articleId(comment.getArticleId())
                     .content(comment.getContent())
                     .depth(comment.getDepth())
                     .parentComment(comment.getParentComment())

--- a/src/main/java/animealth/animealthbackend/api/comment/dto/GetCommentResponseDTO.java
+++ b/src/main/java/animealth/animealthbackend/api/comment/dto/GetCommentResponseDTO.java
@@ -8,13 +8,15 @@ import lombok.Getter;
 public class GetCommentResponseDTO {
 
     private final Long commentId;
+    private final Long articleId;
     private final String writer;
     private final String content;
     private final int depth;
 
     @Builder
-    public GetCommentResponseDTO(Long commentId, String writer, String content, int depth) {
+    public GetCommentResponseDTO(Long commentId, Long articleId, String writer, String content, int depth) {
         this.commentId = commentId;
+        this.articleId = articleId;
         this.writer = writer;
         this.content = content;
         this.depth = depth;
@@ -24,6 +26,7 @@ public class GetCommentResponseDTO {
         if (comment != null) {
             return GetCommentResponseDTO.builder()
                     .commentId(comment.getId())
+                    .articleId(comment.getArticleId())
                     .writer(comment.getWriter().getNickname())
                     .content(comment.getContent())
                     .depth(comment.getDepth())

--- a/src/main/java/animealth/animealthbackend/api/comment/dto/UpdateCommentRequestDTO.java
+++ b/src/main/java/animealth/animealthbackend/api/comment/dto/UpdateCommentRequestDTO.java
@@ -8,5 +8,10 @@ public class UpdateCommentRequestDTO {
     private Long commentId;
     private String content;
 
+    public UpdateCommentRequestDTO(Long commentId, String content) {
+        this.commentId = commentId;
+        this.content = content;
+    }
+
 }
 

--- a/src/main/java/animealth/animealthbackend/api/comment/service/CommentService.java
+++ b/src/main/java/animealth/animealthbackend/api/comment/service/CommentService.java
@@ -26,16 +26,15 @@ public class CommentService {
 
     public CreateCommentResponseDTO saveComment(Long writerId, CreateCommentRequestDTO request) {
         Long parentCommentId = request.getParentCommentId();
-        Optional<Comment> parentComment = Optional.empty();
         User writer = findWriter(writerId);
 
         if (hasParentComment(parentCommentId)) {
-            parentComment = commentRepository.findById(parentCommentId);
-        }
-
-        if (parentComment.isPresent()) {
-            Comment childComment = Comment.of(writer, request.getContent(), parentComment.get(), request.getArticleId());
-            return CreateCommentResponseDTO.from(commentRepository.save(childComment));
+            Optional<Comment> parentComment = commentRepository.findById(parentCommentId);
+            if (parentComment.isPresent()) {
+                Comment childComment = Comment.of(writer, request.getContent(), parentComment.get(), request.getArticleId());
+                parentComment.get().addChildComment(childComment);
+                return CreateCommentResponseDTO.from(commentRepository.save(childComment));
+            }
         }
 
         Comment rootComment = Comment.of(writer, request.getContent(), null, request.getArticleId());

--- a/src/main/java/animealth/animealthbackend/domain/comment/Comment.java
+++ b/src/main/java/animealth/animealthbackend/domain/comment/Comment.java
@@ -19,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.Where;
 
@@ -43,6 +44,7 @@ public class Comment extends BaseEntity {
 
     private int depth;
 
+    @Setter
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "PARENT_COMMENT_ID")
     private Comment parentComment;
@@ -61,7 +63,7 @@ public class Comment extends BaseEntity {
         this.articleId = articleId;
     }
 
-    public static Comment of(User writer, String content, Comment parentComment, Long articleId) {
+    public static Comment of(final User writer, final String content, final Comment parentComment, final Long articleId) {
         return Comment.builder()
                 .writer(writer)
                 .content(content)
@@ -87,6 +89,11 @@ public class Comment extends BaseEntity {
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public void addChildComment(Comment childComment) {
+        childComment.setParentComment(this);
+        this.getChildComments().add(childComment);
     }
 
 }

--- a/src/test/java/animealth/animealthbackend/api/comment/service/CommentServiceTest.java
+++ b/src/test/java/animealth/animealthbackend/api/comment/service/CommentServiceTest.java
@@ -1,0 +1,182 @@
+package animealth.animealthbackend.api.comment.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import animealth.animealthbackend.api.comment.dto.CreateCommentDTO.CreateCommentRequestDTO;
+import animealth.animealthbackend.api.comment.dto.CreateCommentDTO.CreateCommentResponseDTO;
+import animealth.animealthbackend.api.comment.dto.GetCommentResponseDTO;
+import animealth.animealthbackend.api.comment.dto.UpdateCommentRequestDTO;
+import animealth.animealthbackend.domain.article.Article;
+import animealth.animealthbackend.domain.article.ArticleRepository;
+import animealth.animealthbackend.domain.comment.Comment;
+import animealth.animealthbackend.domain.comment.CommentRepository;
+import animealth.animealthbackend.domain.user.Role;
+import animealth.animealthbackend.domain.user.User;
+import animealth.animealthbackend.domain.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class CommentServiceTest {
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private ArticleRepository articleRepository;
+
+    private User writer;
+    private Article article;
+
+    @BeforeEach
+    void setUp() {
+        writer = createCommentWriter("홍길동", "test@test.com", "010-1234-5678", "테스트게정");
+        userRepository.save(writer);
+
+        article = createArticle(writer, "테스트 게시글", "게시글 내용 입력");
+        articleRepository.save(article);
+    }
+
+    @DisplayName("댓글 생성 테스트")
+    @Test
+    void saveComment_test() {
+        // given
+        CreateCommentRequestDTO request = CreateCommentRequestDTO.builder()
+                .parentCommentId(0L)
+                .content("댓글 내용 입력")
+                .articleId(article.getId())
+                .build();
+
+        // when
+        CreateCommentResponseDTO response = commentService.saveComment(writer.getUserId(), request);
+
+        // then
+        assertThat(response).extracting("writer", "articleId", "content", "depth", "parentComment")
+                .containsExactlyInAnyOrder(writer.getNickname(), article.getId(), "댓글 내용 입력", 0, null);
+        assertThat(response.getChildComments()).isEmpty();
+    }
+
+    @DisplayName("대댓글 생성 테스트")
+    @Test
+    void saveChildComment_test() {
+        // given
+        CreateCommentRequestDTO parentRequest = CreateCommentRequestDTO.builder()
+                .parentCommentId(0L)
+                .content("댓글 내용 입력")
+                .articleId(article.getId())
+                .build();
+
+        CreateCommentResponseDTO parentResponse = commentService.saveComment(writer.getUserId(), parentRequest);
+
+        // when
+        CreateCommentRequestDTO childRequest = CreateCommentRequestDTO.builder()
+                .parentCommentId(parentResponse.getCommentId())
+                .content("대댓글입니다.")
+                .articleId(article.getId())
+                .build();
+
+        CreateCommentResponseDTO childResponse = commentService.saveComment(writer.getUserId(), childRequest);
+        GetCommentResponseDTO getParentResponse = commentService.findCommentById(parentResponse.getCommentId());
+
+        // then
+        assertThat(childResponse).extracting("writer", "articleId", "content", "depth")
+                .containsExactlyInAnyOrder(writer.getNickname(), article.getId(), "대댓글입니다.", 1);
+        assertThat(childResponse.getChildComments()).isEmpty();
+        assertThat(childResponse.getParentComment()).usingRecursiveComparison().isEqualTo(getParentResponse);
+
+        assertThat(parentResponse.getChildComments()).hasSize(1);
+    }
+
+    @DisplayName("댓글 조회 테스트")
+    @Test
+    void findComment_By_CommentId_test() {
+        // given
+        CreateCommentRequestDTO saveRequest = CreateCommentRequestDTO.builder()
+                .parentCommentId(0L)
+                .content("댓글 내용 입력")
+                .articleId(article.getId())
+                .build();
+
+        CreateCommentResponseDTO saveResponse = commentService.saveComment(writer.getUserId(), saveRequest);
+
+        // when
+        GetCommentResponseDTO response = commentService.findCommentById(saveResponse.getCommentId());
+
+        //then
+        assertThat(response).extracting("writer", "articleId", "content", "depth")
+                .containsExactlyInAnyOrder(writer.getNickname(), article.getId(), "댓글 내용 입력", 0);
+    }
+
+    @DisplayName("댓글 수정 테스트")
+    @Test
+    void updateComment_test() {
+        // given
+        CreateCommentRequestDTO saveRequest = CreateCommentRequestDTO.builder()
+                .parentCommentId(0L)
+                .content("댓글 내용 입력")
+                .articleId(article.getId())
+                .build();
+
+        CreateCommentResponseDTO saveResponse = commentService.saveComment(writer.getUserId(), saveRequest);
+
+        // when
+        UpdateCommentRequestDTO request = new UpdateCommentRequestDTO(saveResponse.getCommentId(), "수정된 댓글 내용");
+        GetCommentResponseDTO response = commentService.updateComment(request);
+
+        //then
+        assertThat(response).extracting("writer", "content", "depth")
+                .containsExactlyInAnyOrder(writer.getNickname(), "수정된 댓글 내용", 0);
+    }
+
+    @DisplayName("댓글 삭제 테스트")
+    @Test
+    void deleteComment_By_CommentId_test() {
+        // given
+        CreateCommentRequestDTO saveRequest = CreateCommentRequestDTO.builder()
+                .parentCommentId(0L)
+                .content("댓글 내용 입력")
+                .articleId(article.getId())
+                .build();
+
+        CreateCommentResponseDTO saveResponse = commentService.saveComment(writer.getUserId(), saveRequest);
+
+        // when
+        commentService.deleteCommentById(saveResponse.getCommentId());
+
+        //then
+        assertThatThrownBy(() -> commentService.findCommentById(saveResponse.getCommentId()))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Comment Not Found");
+    }
+
+    // Fixture
+    private User createCommentWriter(String name, String email, String phone, String nickname) {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .phone(phone)
+                .nickname(nickname)
+                .role(Role.USER)
+                .build();
+    }
+
+    // Fixture
+    private Article createArticle(User writer, String title, String content) {
+        return Article.of(writer, title, content);
+    }
+
+    // Fixture
+    private Comment createComment(User writer, String content, Comment parentComment, Long articleId) {
+        return Comment.of(writer, content, parentComment, articleId);
+    }
+
+}

--- a/src/test/java/animealth/animealthbackend/domain/comment/CommentRepositoryTest.java
+++ b/src/test/java/animealth/animealthbackend/domain/comment/CommentRepositoryTest.java
@@ -1,0 +1,93 @@
+package animealth.animealthbackend.domain.comment;
+
+import static org.assertj.core.api.Assertions.*;
+
+import animealth.animealthbackend.domain.article.Article;
+import animealth.animealthbackend.domain.article.ArticleRepository;
+import animealth.animealthbackend.domain.user.Role;
+import animealth.animealthbackend.domain.user.User;
+import animealth.animealthbackend.domain.user.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class CommentRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @AfterEach
+    void tearDown() {
+        commentRepository.deleteAllInBatch();
+        articleRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("게시글 고유식별번호를 통해 해당 게시글에 작성된 댓글들 조회")
+    @Test
+    void findComments_By_ArticleId() {
+        User writer = createCommentWriter("홍길동", "test@test.com", "010-1234-5678", "테스트게정");
+        userRepository.save(writer);
+
+        Article article = createArticle(writer, "테스트 게시글", "게시글 내용 입력");
+        articleRepository.save(article);
+
+        Comment comment = createComment(writer, "댓글 내용 입력", null, article.getId());
+        commentRepository.save(comment);
+
+        assertThat(commentRepository.findByArticleId(article.getId())).hasSize(1)
+                .extracting("writer", "content", "parentComment", "articleId")
+                .containsExactlyInAnyOrder(
+                        tuple(writer, "댓글 내용 입력", null, article.getId())
+                );
+    }
+
+    @DisplayName("존재하지 않는 게시글 고유식별번호를 통해 해당 게시글에 작성된 댓글들 조회")
+    @Test
+    void findComments_By_Non_Exists_ArticleId() {
+        User writer = createCommentWriter("홍길동", "test@test.com", "010-1234-5678", "테스트게정");
+        userRepository.save(writer);
+
+        Article article = createArticle(writer, "테스트 게시글", "게시글 내용 입력");
+        articleRepository.save(article);
+
+        Comment comment = createComment(writer, "댓글 내용 입력", null, article.getId());
+        commentRepository.save(comment);
+
+        assertThat(commentRepository.findByArticleId(999999L)).isEmpty();
+    }
+
+    // Fixture
+    private User createCommentWriter(String name, String email, String phone, String nickname) {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .phone(phone)
+                .nickname(nickname)
+                .role(Role.USER)
+                .build();
+    }
+
+    // Fixture
+    private Article createArticle(User writer, String title, String content) {
+        return Article.of(writer, title, content);
+    }
+
+    // Fixture
+    private Comment createComment(User writer, String content, Comment parentComment, Long articleId) {
+        return Comment.of(writer, content, parentComment, articleId);
+    }
+
+}


### PR DESCRIPTION
close #21 단위 테스트 진행 

발견 사항
- 대댓글 작성 시 부모 댓글과 자식 댓글 간의 관계 미설정 => 설정하는 메소드 추가 후 생성 로직 수정
- 조회 및 생성에 대한 응답 DTO에 해당 댓글이 달린 게시글의 고유식별번호 필드 포함